### PR TITLE
feat: Chunking-Service (SPEC-03)

### DIFF
--- a/src/openaustria_rag/ingestion/chunking.py
+++ b/src/openaustria_rag/ingestion/chunking.py
@@ -1,0 +1,317 @@
+"""Semantic chunking service for code, documentation, and config files (SPEC-03 Section 4)."""
+
+import uuid
+
+from ..connectors.utils import detect_language
+from ..models import Chunk, ChunkMetadata, CodeElement, ElementKind
+
+
+def _estimate_tokens(text: str) -> int:
+    """Rough token estimate: ~4 characters per token."""
+    return len(text) // 4
+
+
+class ChunkingService:
+    """Create semantic chunks from documents."""
+
+    def __init__(
+        self,
+        code_max_tokens: int = 2048,
+        doc_max_tokens: int = 1024,
+        doc_min_tokens: int = 64,
+        doc_overlap_tokens: int = 128,
+        config_max_tokens: int = 2048,
+        include_context_header: bool = True,
+    ):
+        self.code_max_tokens = code_max_tokens
+        self.doc_max_tokens = doc_max_tokens
+        self.doc_min_tokens = doc_min_tokens
+        self.doc_overlap_tokens = doc_overlap_tokens
+        self.config_max_tokens = config_max_tokens
+        self.include_context_header = include_context_header
+
+    def chunk(
+        self,
+        content: str,
+        content_type: str,
+        file_path: str,
+        document_id: str = "",
+        language: str | None = None,
+        code_elements: list[CodeElement] | None = None,
+    ) -> list[Chunk]:
+        """Route to the appropriate chunking strategy."""
+        if content_type == "code" and code_elements:
+            return self._chunk_code(content, file_path, document_id, code_elements)
+        elif content_type == "documentation":
+            return self._chunk_documentation(content, file_path, document_id)
+        else:
+            return self._chunk_simple(content, file_path, document_id, content_type)
+
+    def _chunk_code(
+        self,
+        content: str,
+        file_path: str,
+        document_id: str,
+        code_elements: list[CodeElement],
+    ) -> list[Chunk]:
+        """Chunk along code structure boundaries (tree-sitter-based)."""
+        chunks: list[Chunk] = []
+        lines = content.split("\n")
+        covered_lines: set[int] = set()
+
+        top_level = sorted(
+            [e for e in code_elements if e.parent_id is None],
+            key=lambda e: e.start_line,
+        )
+
+        for element in top_level:
+            start = element.start_line - 1  # 0-based
+            end = element.end_line
+            element_content = "\n".join(lines[start:end])
+
+            if self.include_context_header:
+                header = f"# File: {file_path}\n# Element: {element.name} ({element.kind.value})\n\n"
+                element_content = header + element_content
+
+            token_count = _estimate_tokens(element_content)
+
+            if token_count <= self.code_max_tokens:
+                chunks.append(Chunk(
+                    id=str(uuid.uuid4()),
+                    document_id=document_id,
+                    content=element_content,
+                    chunk_index=len(chunks),
+                    token_count=token_count,
+                    metadata=ChunkMetadata(
+                        source_type="code",
+                        language=detect_language(file_path) or "",
+                        file_path=file_path,
+                        element_type=element.kind.value,
+                        element_name=element.name,
+                        start_line=element.start_line,
+                        end_line=element.end_line,
+                    ),
+                ))
+            else:
+                # Element too large: chunk children individually
+                children = [e for e in code_elements if e.parent_id == element.id]
+                if children:
+                    for child in sorted(children, key=lambda c: c.start_line):
+                        child_start = child.start_line - 1
+                        child_end = child.end_line
+                        child_content = "\n".join(lines[child_start:child_end])
+
+                        if self.include_context_header:
+                            header = f"# File: {file_path}\n# Element: {child.name} ({child.kind.value})\n\n"
+                            child_content = header + child_content
+
+                        chunks.append(Chunk(
+                            id=str(uuid.uuid4()),
+                            document_id=document_id,
+                            content=child_content,
+                            chunk_index=len(chunks),
+                            token_count=_estimate_tokens(child_content),
+                            metadata=ChunkMetadata(
+                                source_type="code",
+                                language=detect_language(file_path) or "",
+                                file_path=file_path,
+                                element_type=child.kind.value,
+                                element_name=child.name,
+                                parent_element=element.short_name,
+                                start_line=child.start_line,
+                                end_line=child.end_line,
+                            ),
+                        ))
+                else:
+                    # No children: split by token boundary
+                    for sub in _split_with_overlap(
+                        element_content, self.code_max_tokens, self.doc_overlap_tokens
+                    ):
+                        chunks.append(Chunk(
+                            id=str(uuid.uuid4()),
+                            document_id=document_id,
+                            content=sub,
+                            chunk_index=len(chunks),
+                            token_count=_estimate_tokens(sub),
+                            metadata=ChunkMetadata(
+                                source_type="code",
+                                file_path=file_path,
+                                element_type=element.kind.value,
+                                element_name=element.name,
+                            ),
+                        ))
+
+            covered_lines.update(range(start, end))
+
+        # Uncovered lines (imports, etc.) as additional chunk
+        uncovered = [
+            line for i, line in enumerate(lines)
+            if i not in covered_lines and line.strip()
+        ]
+        if uncovered and _estimate_tokens("\n".join(uncovered)) >= 32:
+            uncovered_content = "\n".join(uncovered)
+            if self.include_context_header:
+                uncovered_content = f"# File: {file_path}\n# Element: (file-level declarations)\n\n" + uncovered_content
+            chunks.append(Chunk(
+                id=str(uuid.uuid4()),
+                document_id=document_id,
+                content=uncovered_content,
+                chunk_index=len(chunks),
+                token_count=_estimate_tokens(uncovered_content),
+                metadata=ChunkMetadata(
+                    source_type="code",
+                    file_path=file_path,
+                    element_type="file_level",
+                    element_name=file_path,
+                ),
+            ))
+
+        return chunks
+
+    def _chunk_documentation(
+        self, content: str, file_path: str, document_id: str
+    ) -> list[Chunk]:
+        """Chunk along Markdown headers."""
+        chunks: list[Chunk] = []
+        sections = _split_by_headers(content)
+
+        for section in sections:
+            token_count = _estimate_tokens(section["content"])
+
+            if token_count < self.doc_min_tokens:
+                continue
+
+            if token_count <= self.doc_max_tokens:
+                chunks.append(Chunk(
+                    id=str(uuid.uuid4()),
+                    document_id=document_id,
+                    content=section["content"],
+                    chunk_index=len(chunks),
+                    token_count=token_count,
+                    metadata=ChunkMetadata(
+                        source_type="documentation",
+                        language="markdown",
+                        file_path=file_path,
+                        element_type="section",
+                        element_name=section.get("header", file_path),
+                    ),
+                ))
+            else:
+                for sub in _split_with_overlap(
+                    section["content"], self.doc_max_tokens, self.doc_overlap_tokens
+                ):
+                    chunks.append(Chunk(
+                        id=str(uuid.uuid4()),
+                        document_id=document_id,
+                        content=sub,
+                        chunk_index=len(chunks),
+                        token_count=_estimate_tokens(sub),
+                        metadata=ChunkMetadata(
+                            source_type="documentation",
+                            language="markdown",
+                            file_path=file_path,
+                            element_type="section",
+                            element_name=section.get("header", file_path),
+                        ),
+                    ))
+
+        return chunks
+
+    def _chunk_simple(
+        self, content: str, file_path: str, document_id: str, content_type: str
+    ) -> list[Chunk]:
+        """Simple chunking for config files etc."""
+        token_count = _estimate_tokens(content)
+        if token_count <= self.config_max_tokens:
+            return [Chunk(
+                id=str(uuid.uuid4()),
+                document_id=document_id,
+                content=content,
+                chunk_index=0,
+                token_count=token_count,
+                metadata=ChunkMetadata(
+                    source_type=content_type,
+                    file_path=file_path,
+                    element_type="file",
+                    element_name=file_path,
+                ),
+            )]
+
+        result = []
+        for sub in _split_with_overlap(
+            content, self.config_max_tokens, self.doc_overlap_tokens
+        ):
+            result.append(Chunk(
+                id=str(uuid.uuid4()),
+                document_id=document_id,
+                content=sub,
+                chunk_index=len(result),
+                token_count=_estimate_tokens(sub),
+                metadata=ChunkMetadata(
+                    source_type=content_type,
+                    file_path=file_path,
+                    element_type="file",
+                    element_name=file_path,
+                ),
+            ))
+        return result
+
+
+def _split_by_headers(content: str) -> list[dict]:
+    """Split Markdown content at H1/H2/H3 headers."""
+    sections: list[dict] = []
+    current_header = ""
+    current_lines: list[str] = []
+
+    for line in content.split("\n"):
+        if line.startswith(("# ", "## ", "### ")):
+            if current_lines:
+                sections.append({
+                    "header": current_header,
+                    "content": "\n".join(current_lines),
+                })
+            current_header = line.lstrip("#").strip()
+            current_lines = [line]
+        else:
+            current_lines.append(line)
+
+    if current_lines:
+        sections.append({
+            "header": current_header,
+            "content": "\n".join(current_lines),
+        })
+
+    return sections
+
+
+def _split_with_overlap(
+    content: str, max_tokens: int, overlap_tokens: int
+) -> list[str]:
+    """Split text into chunks with overlap between paragraphs."""
+    paragraphs = content.split("\n\n")
+    chunks: list[str] = []
+    current_chunk: list[str] = []
+    current_tokens = 0
+
+    for para in paragraphs:
+        para_tokens = _estimate_tokens(para)
+        if current_tokens + para_tokens > max_tokens and current_chunk:
+            chunks.append("\n\n".join(current_chunk))
+            # Keep trailing paragraphs for overlap
+            overlap_chunk: list[str] = []
+            overlap_count = 0
+            for p in reversed(current_chunk):
+                pt = _estimate_tokens(p)
+                if overlap_count + pt > overlap_tokens:
+                    break
+                overlap_chunk.insert(0, p)
+                overlap_count += pt
+            current_chunk = overlap_chunk
+            current_tokens = overlap_count
+        current_chunk.append(para)
+        current_tokens += para_tokens
+
+    if current_chunk:
+        chunks.append("\n\n".join(current_chunk))
+
+    return chunks

--- a/tests/test_ingestion/test_chunking.py
+++ b/tests/test_ingestion/test_chunking.py
@@ -1,0 +1,221 @@
+"""Tests for the chunking service (SPEC-03 Section 4)."""
+
+import pytest
+
+from openaustria_rag.ingestion.chunking import (
+    ChunkingService,
+    _estimate_tokens,
+    _split_by_headers,
+    _split_with_overlap,
+)
+from openaustria_rag.models import Chunk, CodeElement, ElementKind
+
+
+@pytest.fixture
+def service():
+    return ChunkingService()
+
+
+def _make_element(
+    name, kind=ElementKind.CLASS, start=1, end=10, parent_id=None, doc_id="doc1"
+):
+    return CodeElement(
+        id=f"elem-{name}",
+        document_id=doc_id,
+        kind=kind,
+        name=name,
+        short_name=name.split(".")[-1],
+        file_path="test.py",
+        start_line=start,
+        end_line=end,
+        parent_id=parent_id,
+    )
+
+
+PYTHON_CODE = """\
+import os
+import sys
+
+class UserService:
+    def get_users(self):
+        return []
+
+    def create_user(self, name):
+        return {"name": name}
+
+def standalone():
+    pass"""
+
+
+class TestCodeChunking:
+    def test_chunks_along_class_boundary(self, service):
+        elements = [
+            _make_element("UserService", ElementKind.CLASS, 4, 10),
+            _make_element("UserService.get_users", ElementKind.FUNCTION, 5, 6, parent_id="elem-UserService"),
+            _make_element("UserService.create_user", ElementKind.FUNCTION, 8, 9, parent_id="elem-UserService"),
+            _make_element("standalone", ElementKind.FUNCTION, 12, 13),
+        ]
+        chunks = service.chunk(PYTHON_CODE, "code", "service.py", "doc1", code_elements=elements)
+        assert len(chunks) >= 2  # At least class + standalone
+
+    def test_context_header_present(self, service):
+        elements = [_make_element("UserService", ElementKind.CLASS, 4, 10)]
+        chunks = service.chunk(PYTHON_CODE, "code", "service.py", "doc1", code_elements=elements)
+        assert chunks[0].content.startswith("# File: service.py")
+        assert "# Element: UserService (class)" in chunks[0].content
+
+    def test_context_header_disabled(self):
+        service = ChunkingService(include_context_header=False)
+        elements = [_make_element("UserService", ElementKind.CLASS, 4, 10)]
+        chunks = service.chunk(PYTHON_CODE, "code", "service.py", "doc1", code_elements=elements)
+        assert not chunks[0].content.startswith("# File:")
+
+    def test_metadata_populated(self, service):
+        elements = [_make_element("UserService", ElementKind.CLASS, 4, 10)]
+        chunks = service.chunk(PYTHON_CODE, "code", "service.py", "doc1", code_elements=elements)
+        meta = chunks[0].metadata
+        assert meta.source_type == "code"
+        assert meta.file_path == "service.py"
+        assert meta.element_type == "class"
+        assert meta.element_name == "UserService"
+        assert meta.start_line == 4
+
+    def test_uncovered_lines_collected(self, service):
+        elements = [_make_element("UserService", ElementKind.CLASS, 4, 10)]
+        # Lines 1-3 (imports) and 12-13 (standalone) are uncovered
+        code = "import os\nimport sys\nimport json\n\n" + "x = 1\n" * 30 + "\nclass UserService:\n    pass\n"
+        elements = [_make_element("UserService", ElementKind.CLASS, 36, 37)]
+        chunks = service.chunk(code, "code", "service.py", "doc1", code_elements=elements)
+        file_level = [c for c in chunks if c.metadata.element_type == "file_level"]
+        assert len(file_level) == 1
+
+    def test_large_element_splits_children(self):
+        service = ChunkingService(code_max_tokens=10)  # Very small limit
+        elements = [
+            _make_element("BigClass", ElementKind.CLASS, 4, 10),
+            _make_element("BigClass.method1", ElementKind.FUNCTION, 5, 6, parent_id="elem-BigClass"),
+            _make_element("BigClass.method2", ElementKind.FUNCTION, 8, 9, parent_id="elem-BigClass"),
+        ]
+        chunks = service.chunk(PYTHON_CODE, "code", "service.py", "doc1", code_elements=elements)
+        method_chunks = [c for c in chunks if c.metadata.element_type == "function"]
+        assert len(method_chunks) == 2
+
+    def test_document_id_preserved(self, service):
+        elements = [_make_element("UserService", ElementKind.CLASS, 4, 10)]
+        chunks = service.chunk(PYTHON_CODE, "code", "service.py", "my-doc", code_elements=elements)
+        for c in chunks:
+            assert c.document_id == "my-doc"
+
+    def test_chunk_index_sequential(self, service):
+        elements = [
+            _make_element("UserService", ElementKind.CLASS, 4, 10),
+            _make_element("standalone", ElementKind.FUNCTION, 12, 13),
+        ]
+        chunks = service.chunk(PYTHON_CODE, "code", "service.py", "doc1", code_elements=elements)
+        for i, chunk in enumerate(chunks):
+            assert chunk.chunk_index == i
+
+
+MARKDOWN_DOC = """\
+# Introduction
+
+This is the intro paragraph with enough text to pass the minimum token threshold for chunking purposes. The system is designed to handle large-scale document processing with multiple connectors and a modular pipeline architecture that supports incremental updates and efficient resource usage across different deployment scenarios.
+
+## Architecture
+
+The system uses a layered architecture with multiple components that interact through well-defined interfaces. Each layer is responsible for a specific set of operations and communicates with adjacent layers through typed data contracts. The architecture supports both local and cloud deployment models with configurable backends for storage and compute.
+
+### Components
+
+Each component is responsible for a specific domain function and communicates via message passing. Components can be deployed independently and scaled horizontally to handle increased load patterns.
+
+## Deployment
+
+The application is deployed using Docker containers orchestrated by Kubernetes in production. Configuration is managed through environment variables and YAML files that support per-environment overrides for development, staging, and production environments.
+"""
+
+
+class TestDocumentationChunking:
+    def test_splits_at_headers(self, service):
+        chunks = service.chunk(MARKDOWN_DOC, "documentation", "README.md", "doc1")
+        assert len(chunks) >= 2
+
+    def test_section_metadata(self, service):
+        chunks = service.chunk(MARKDOWN_DOC, "documentation", "README.md", "doc1")
+        headers = [c.metadata.element_name for c in chunks]
+        assert "Introduction" in headers or "Architecture" in headers
+
+    def test_skips_short_sections(self):
+        service = ChunkingService(doc_min_tokens=1000)  # High threshold
+        chunks = service.chunk(MARKDOWN_DOC, "documentation", "README.md", "doc1")
+        assert len(chunks) == 0  # All sections too short
+
+    def test_large_section_splits_with_overlap(self):
+        service = ChunkingService(doc_max_tokens=20, doc_overlap_tokens=5)
+        long_section = "# Big Section\n\n" + "\n\n".join(
+            f"Paragraph {i} with some content to make it longer." for i in range(20)
+        )
+        chunks = service.chunk(long_section, "documentation", "doc.md", "doc1")
+        assert len(chunks) > 1
+
+    def test_source_type_is_documentation(self, service):
+        chunks = service.chunk(MARKDOWN_DOC, "documentation", "README.md", "doc1")
+        for c in chunks:
+            assert c.metadata.source_type == "documentation"
+
+
+class TestConfigChunking:
+    def test_small_config_single_chunk(self, service):
+        config = "key: value\nother: data\n"
+        chunks = service.chunk(config, "config", "config.yaml", "doc1")
+        assert len(chunks) == 1
+        assert chunks[0].content == config
+        assert chunks[0].metadata.element_type == "file"
+
+    def test_large_config_splits(self):
+        service = ChunkingService(config_max_tokens=20)
+        config = "\n\n".join(f"key_{i}: value_{i}" for i in range(50))
+        chunks = service.chunk(config, "config", "big.yaml", "doc1")
+        assert len(chunks) > 1
+
+    def test_code_without_elements_uses_simple(self, service):
+        code = "x = 1\ny = 2\n"
+        chunks = service.chunk(code, "code", "script.py", "doc1", code_elements=None)
+        assert len(chunks) == 1  # Falls back to simple chunking
+
+
+class TestHelpers:
+    def test_estimate_tokens(self):
+        assert _estimate_tokens("") == 0
+        assert _estimate_tokens("abcd") == 1
+        assert _estimate_tokens("a" * 100) == 25
+
+    def test_split_by_headers(self):
+        md = "# A\nContent A\n## B\nContent B\n"
+        sections = _split_by_headers(md)
+        assert len(sections) == 2
+        assert sections[0]["header"] == "A"
+        assert sections[1]["header"] == "B"
+
+    def test_split_by_headers_no_headers(self):
+        sections = _split_by_headers("Just plain text\nMore text")
+        assert len(sections) == 1
+        assert sections[0]["header"] == ""
+
+    def test_split_with_overlap(self):
+        text = "\n\n".join(f"Paragraph {i} content." for i in range(10))
+        chunks = _split_with_overlap(text, max_tokens=30, overlap_tokens=10)
+        assert len(chunks) > 1
+        # Check overlap: last paragraph of chunk N should appear in chunk N+1
+        if len(chunks) >= 2:
+            last_para_of_first = chunks[0].split("\n\n")[-1]
+            assert last_para_of_first in chunks[1]
+
+    def test_split_with_overlap_small_content(self):
+        chunks = _split_with_overlap("small text", max_tokens=100, overlap_tokens=10)
+        assert len(chunks) == 1
+        assert chunks[0] == "small text"
+
+    def test_token_count_populated(self, service=ChunkingService()):
+        chunks = service.chunk("key: value\n", "config", "c.yaml", "doc1")
+        assert chunks[0].token_count > 0


### PR DESCRIPTION
## Summary
- ChunkingService with three strategies: code (tree-sitter boundaries), documentation (Markdown headers), config (whole file)
- Code chunking: context headers, parent-child splitting for large elements, uncovered line collection
- Documentation chunking: header-based splits, min token threshold, paragraph overlap for large sections
- Helper functions: `_estimate_tokens`, `_split_by_headers`, `_split_with_overlap`

Closes #6

## Changes
- `src/openaustria_rag/ingestion/chunking.py` — ChunkingService + helper functions
- `tests/test_ingestion/test_chunking.py` — 22 tests

## Test Plan
- [x] Code chunks follow class/method boundaries
- [x] Context headers present and toggleable
- [x] Large elements split into child chunks
- [x] Uncovered lines (imports) collected
- [x] Doc chunking splits at headers with min threshold
- [x] Overlap between doc chunks
- [x] Config as single chunk or with overlap
- [x] `pytest tests/` — 169/169 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)