### PR TITLE
fix: Streamlit relative imports broken

### DIFF
--- a/src/openaustria_rag/frontend/app.py
+++ b/src/openaustria_rag/frontend/app.py
@@ -2,7 +2,7 @@
 
 import streamlit as st
 
-from .api_client import APIClient
+from openaustria_rag.frontend.api_client import APIClient
 
 API_URL = "http://localhost:8000"
 

--- a/src/openaustria_rag/frontend/pages/01_Projekte.py
+++ b/src/openaustria_rag/frontend/pages/01_Projekte.py
@@ -2,7 +2,7 @@
 
 import streamlit as st
 
-from ..app import get_client, init_session_state, render_sidebar
+from openaustria_rag.frontend.app import get_client, init_session_state, render_sidebar
 
 
 def main():

--- a/src/openaustria_rag/frontend/pages/02_Chat.py
+++ b/src/openaustria_rag/frontend/pages/02_Chat.py
@@ -4,7 +4,7 @@ import uuid
 
 import streamlit as st
 
-from ..app import get_client, init_session_state, render_sidebar
+from openaustria_rag.frontend.app import get_client, init_session_state, render_sidebar
 
 
 def main():

--- a/src/openaustria_rag/frontend/pages/03_Gap_Analyse.py
+++ b/src/openaustria_rag/frontend/pages/03_Gap_Analyse.py
@@ -4,7 +4,7 @@ import json
 
 import streamlit as st
 
-from ..app import get_client, init_session_state, render_sidebar
+from openaustria_rag.frontend.app import get_client, init_session_state, render_sidebar
 
 SEVERITY_BADGES = {
     "critical": "🔴",

--- a/src/openaustria_rag/frontend/pages/04_Quellen.py
+++ b/src/openaustria_rag/frontend/pages/04_Quellen.py
@@ -2,7 +2,7 @@
 
 import streamlit as st
 
-from ..app import get_client, init_session_state, render_sidebar
+from openaustria_rag.frontend.app import get_client, init_session_state, render_sidebar
 
 SOURCE_TYPE_ICONS = {"git": "🔗", "zip": "📦", "confluence": "📄"}
 

--- a/src/openaustria_rag/frontend/pages/05_Einstellungen.py
+++ b/src/openaustria_rag/frontend/pages/05_Einstellungen.py
@@ -2,7 +2,7 @@
 
 import streamlit as st
 
-from ..app import get_client, init_session_state, render_sidebar
+from openaustria_rag.frontend.app import get_client, init_session_state, render_sidebar
 
 
 def main():


### PR DESCRIPTION
## Summary
Streamlit runs pages as standalone scripts, causing `ImportError: attempted relative import with no known parent package`. Changed all relative imports (`from ..app`, `from .api_client`) to absolute imports (`from openaustria_rag.frontend.app`, etc.).

Closes #31

## Changes
- `src/openaustria_rag/frontend/app.py` — `from .api_client` → `from openaustria_rag.frontend.api_client`
- `src/openaustria_rag/frontend/pages/*.py` — `from ..app` → `from openaustria_rag.frontend.app`

## Test Plan
- [x] `pytest tests/` — 305/305 passing
- [ ] `streamlit run src/openaustria_rag/frontend/app.py` startet ohne ImportError

🤖 Generated with [Claude Code](https://claude.com/claude-code)