### PR TITLE
fix: Isolate API tests from production database

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,8 +11,13 @@ from fastapi.testclient import TestClient
 def client(tmp_path, monkeypatch):
     """Create a test client with services pointing to tmp_path."""
     import openaustria_rag.config as cfg
+    import openaustria_rag.db as db_mod
+    import openaustria_rag.retrieval.vector_store as vs_mod
+
     monkeypatch.setattr(cfg, "PROJECT_ROOT", tmp_path)
     monkeypatch.setattr(cfg, "DEFAULT_CONFIG_PATH", tmp_path / "config.yaml")
+    monkeypatch.setattr(db_mod, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(vs_mod, "PROJECT_ROOT", tmp_path)
 
     # Patch EmbeddingService and LLMService to not connect to Ollama
     with patch("openaustria_rag.frontend.api.EmbeddingService") as mock_emb_cls, \


### PR DESCRIPTION
## Summary
- Patched `PROJECT_ROOT` in `db` and `vector_store` modules (not just `config`) so API tests use `tmp_path` instead of the production `data/` directory
- Root cause: `from .config import PROJECT_ROOT` creates independent name bindings that aren't affected by monkeypatching the `config` module alone

Closes #33

## Test Plan
- [x] `pytest tests/test_api.py` — 17/17 passed
- [x] `data/openaustria_rag.db` timestamp unchanged after test run

🤖 Generated with [Claude Code](https://claude.com/claude-code)